### PR TITLE
Add G1 scheme conformant to Hash to Curve RFC

### DIFF
--- a/drand_core/src/chain.rs
+++ b/drand_core/src/chain.rs
@@ -241,6 +241,21 @@ pub mod tests {
         }"#).unwrap()
     }
 
+    /// From drand Slack https://drandworkspace.slack.com/archives/C02FWA217GF/p1686583505902169
+    pub fn unchained_chain_on_g1_rfc_info() -> ChainInfo {
+        serde_json::from_str(r#"{
+            "public_key": "a1ee12542360bf75742bcade13d6134e7d5283d9eb782887c47d3d9725f05805d37b0106b7f744395bf82c175dd7434a169e998f188a657a030d588892c0cd2c01f996aaf331c4d8bc5b9734bbe261d09e7d2d39ef88b635077f262bd7bbb30f",
+            "period": 3,
+            "genesis_time": 1677685200,
+            "hash": "dbd506d6ef76e5f386f41c651dcb808c5bcbd75471cc4eafa3f4df7ad4e4c493",
+            "groupHash": "a81e9d63f614ccdb144b8ff79fbd4d5a2d22055c0bfe4ee9a8092003dab1c6c0",
+            "schemeID": "bls-unchained-g1-rfc",
+            "metadata": {
+              "beaconID": "does-not-exist-slacn"
+            }
+        }"#).unwrap()
+    }
+
     #[test]
     fn chain_verification_success_works() {
         // Full validation should pass

--- a/drand_core/src/libp2p_client.rs
+++ b/drand_core/src/libp2p_client.rs
@@ -1,0 +1,42 @@
+use anyhow::Result;
+use libp2p::futures::StreamExt;
+use libp2p::swarm::{keep_alive, NetworkBehaviour, SwarmBuilder, SwarmEvent};
+use libp2p::{identity, ping, Multiaddr, PeerId};
+
+pub async fn test() -> Result<()> {
+    let local_key = identity::Keypair::generate_ed25519();
+    let local_peer_id = PeerId::from(local_key.public());
+    println!("Local peer id: {local_peer_id:?}");
+
+    let transport = libp2p::development_transport(local_key).await?;
+
+    let behaviour = Behaviour::default();
+
+    let mut swarm = SwarmBuilder::with_async_std_executor(transport, behaviour, local_peer_id).build();
+
+    swarm.listen_on("/ip4/0.0.0.0/tcp/0".parse()?)?;
+
+    // Dial the peer identified by the multi-address given as the second
+    // command-line argument, if any.
+    if let Some(addr) = Some("/dnsaddr/api.drand.sh") {
+        let remote: Multiaddr = addr.parse()?;
+        swarm.dial(remote)?;
+        println!("Dialed {addr}")
+    }
+
+    loop {
+      match swarm.select_next_some().await {
+          SwarmEvent::NewListenAddr { address, .. } => println!("Listening on {address:?}"),
+          SwarmEvent::Behaviour(event) => println!("{event:?}"),
+          _ => {}
+      }
+    }
+
+    Ok(())
+}
+
+#[derive(NetworkBehaviour, Default)]
+struct Behaviour {
+    keep_alive: keep_alive::Behaviour,
+    ping: ping::Behaviour,
+}


### PR DESCRIPTION
This updates `drand_core` to have a custom domain for G1 and G2 when performing verification. This is going to support a new drand network: `bls-unchained-g1-rfc`.

This commit adds one test vector for said network, as well as regression tests to make sure current G1 network is still supported.

Finally, internal method `scheme_id` is removed from `RandomnessBeacon`, as it derived data that should not have existed solely on the beacon, without chain information. Its usage is replaced by distinct methods `is_unchained` and `is_g1`.

Closes #2