### PR TITLE
Add built-in time estimation for drand_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "dee"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "drand_core"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "ark-bls12-381",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "time",
  "ureq",
  "url",
 ]

--- a/dee/CHANGELOG.md
+++ b/dee/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.0.10] - 2023-08-08
+
+### Changed
+
+- Update dependencies
+
 ## [0.0.9] - 2023-08-01
 
 ### Fix

--- a/dee/Cargo.toml
+++ b/dee/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dee"
 description = "An cli for drand, with support for timelock encryption."
-version = "0.0.9"
+version = "0.0.10"
 authors = ["Thibault Meunier <crates@thibault.uk>"]
 edition = "2021"
 readme = "../README.md"
@@ -39,7 +39,7 @@ clap = { version = "4.3.19", features = ["derive"] }
 clap-verbosity-flag = "2.0.1"
 colored = "2.0.4"
 confy = "0.5.1"
-drand_core = { path = "../drand_core", version = "0.0.9" }
+drand_core = { path = "../drand_core", version = "0.0.10" }
 env_logger = "0.10.0"
 hex = "0.4.3"
 log = "0.4.19"

--- a/dee/src/cmd/crypt.rs
+++ b/dee/src/cmd/crypt.rs
@@ -1,12 +1,9 @@
 use std::{fs, io};
 
 use anyhow::{anyhow, Result};
-use drand_core::{ChainOptions, HttpClient};
+use drand_core::{beacon::RandomnessBeaconTime, ChainOptions, HttpClient};
 
-use crate::{
-    config::{self, ConfigChain},
-    time::RandomnessBeaconTime,
-};
+use crate::config::{self, ConfigChain};
 
 pub fn file_or_stdin(input: Option<String>) -> Result<Box<dyn io::Read>> {
     let reader: Box<dyn io::Read> = match input {

--- a/dee/src/cmd/rand.rs
+++ b/dee/src/cmd/rand.rs
@@ -3,13 +3,15 @@ use std::cmp::Ordering;
 use anyhow::Result;
 
 use colored::Colorize;
-use drand_core::{beacon::RandomnessBeacon, ChainOptions, HttpClient};
+use drand_core::{
+    beacon::{RandomnessBeacon, RandomnessBeaconTime},
+    ChainOptions, HttpClient,
+};
 use serde::Serialize;
 
 use crate::{
     config::{self, ConfigChain},
     print::{print_with_format, Format, Print},
-    time::RandomnessBeaconTime,
 };
 
 #[derive(Serialize)]

--- a/dee/src/time.rs
+++ b/dee/src/time.rs
@@ -1,101 +1,11 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use colored::Colorize;
-use drand_core::chain::ChainInfo;
+use drand_core::beacon::RandomnessBeaconTime;
 use drand_core::{ChainOptions, HttpClient};
-use serde::{Deserialize, Serialize};
-use time::ext::NumericalDuration;
 use time::format_description::well_known::Rfc3339;
-use time::{Duration, OffsetDateTime};
 
 use crate::config::ConfigChain;
 use crate::print::Print;
-
-fn parse_duration(duration: &str) -> Result<Duration> {
-    let l = duration.len() - 1;
-    let principal = duration[0..l].parse::<i64>()?;
-
-    let duration = match duration.chars().last().unwrap() {
-        's' => principal.seconds(),
-        'm' => principal.minutes(),
-        'h' => principal.hours(),
-        'd' => principal.days(),
-        _ => return Err(anyhow!("cannot parse duration")),
-    };
-    Ok(duration)
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct RandomnessBeaconTime {
-    round: u64,
-    relative: Duration,
-    #[serde(with = "time::serde::rfc3339")]
-    absolute: OffsetDateTime,
-}
-
-impl RandomnessBeaconTime {
-    pub fn new(info: &ChainInfo, round: &str) -> Self {
-        match (
-            round.parse::<u64>(),
-            parse_duration(round),
-            OffsetDateTime::parse(round, &Rfc3339),
-        ) {
-            (Ok(round), Err(_), Err(_)) => Self::from_round(info, round),
-            (Err(_), Ok(relative), Err(_)) => Self::from_duration(info, relative),
-            (Err(_), Err(_), Ok(absolute)) => Self::from_datetime(info, absolute),
-            _ => unreachable!(),
-        }
-    }
-
-    pub fn round(&self) -> u64 {
-        self.round
-    }
-
-    pub fn relative(&self) -> Duration {
-        self.relative
-    }
-
-    pub fn absolute(&self) -> OffsetDateTime {
-        self.absolute
-    }
-
-    pub fn from_round(info: &ChainInfo, round: u64) -> Self {
-        let genesis = OffsetDateTime::from_unix_timestamp(info.genesis_time() as i64).unwrap();
-
-        let absolute = genesis + (((round - 1) * info.period()) as i64).seconds();
-        let relative = absolute - OffsetDateTime::now_utc();
-        Self {
-            round,
-            relative,
-            absolute,
-        }
-    }
-
-    fn from_duration(info: &ChainInfo, relative: Duration) -> Self {
-        let genesis = OffsetDateTime::from_unix_timestamp(info.genesis_time() as i64).unwrap();
-
-        let absolute = OffsetDateTime::now_utc() + relative;
-        let round = ((absolute - genesis).whole_seconds() / (info.period() as i64) + 1) as u64;
-
-        Self {
-            round,
-            relative,
-            absolute,
-        }
-    }
-
-    fn from_datetime(info: &ChainInfo, absolute: OffsetDateTime) -> Self {
-        let genesis = OffsetDateTime::from_unix_timestamp(info.genesis_time() as i64).unwrap();
-
-        let relative = absolute - OffsetDateTime::now_utc();
-        let round = ((absolute - genesis).whole_seconds() / (info.period() as i64) + 1) as u64;
-
-        Self {
-            round,
-            relative,
-            absolute,
-        }
-    }
-}
 
 impl Print for RandomnessBeaconTime {
     fn short(&self) -> Result<String> {

--- a/drand_core/CHANGELOG.md
+++ b/drand_core/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [0.0.10] - 2023-08-08
+
 ### Added
 
 - Built-in beacon time estimation

--- a/drand_core/CHANGELOG.md
+++ b/drand_core/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Built-in beacon time estimation
+
+### Fix
+
+- Wasm32 build
+
 ## [0.0.9] - 2023-08-01
 
 ### Changed

--- a/drand_core/Cargo.toml
+++ b/drand_core/Cargo.toml
@@ -22,11 +22,19 @@ rand = "0.8.5"
 serde = { version = "1.0.174", features = ["derive", "rc"] }
 serde_json = "1.0.103"
 sha2 = "0.10.7"
+time = { version = "0.3.23", features = ["parsing", "serde-well-known"], optional = true }
 ureq = { version = "2.7.1", features = ["json"] }
 url = { version = "2.4", features = ["serde"] }
 
 [target.'cfg(wasm32)'.dependencies]
 getrandom = { version = "0.2.10", features = ["js"] }
+
+[features]
+default = ["time"]
+time = ["dep:time"]
+
+[target.'cfg(wasm32)'.features]
+default = []
 
 [dev-dependencies]
 hex-literal = "0.4.1"

--- a/drand_core/Cargo.toml
+++ b/drand_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "drand_core"
 description = "A drand client library."
-version = "0.0.9"
+version = "0.0.10"
 authors = ["Thibault Meunier <crates@thibault.uk>"]
 edition = "2021"
 readme = "./README.md"

--- a/drand_core/README.md
+++ b/drand_core/README.md
@@ -26,6 +26,7 @@ The reference interroperable Go implementation is available at [drand/drand](htt
 ## Features
 
 * Retrieve and verify drand randomness
+* Built-in beacon time estimation
 * Chain and unchained randomness
 * Signatures verification on G1 and G2
 * Interroperability with Go and JS implementation
@@ -34,7 +35,6 @@ The reference interroperable Go implementation is available at [drand/drand](htt
 ## What's next
 
 * P2P randomness retrieval
-* Built-in beacon time estimation
 
 ## Installation
 

--- a/drand_core/src/chain.rs
+++ b/drand_core/src/chain.rs
@@ -56,7 +56,7 @@ impl ChainInfo {
         self.period
     }
 
-    /// Time of the round 0 of the network (in epoch seconds).
+    /// Time of the round 1 of the network (in epoch seconds).
     pub fn genesis_time(&self) -> u64 {
         self.genesis_time
     }


### PR DESCRIPTION
More information can be retrieved from a given beacon time. It also provides a convenient way to parse input, for instance "30s" for a beacon in the future.