### PR TITLE
Add a check on the returned round value

### DIFF
--- a/drand_core/README.md
+++ b/drand_core/README.md
@@ -54,7 +54,7 @@ use drand_core::HttpClient;
 // Create a new client.
 let client: HttpClient = "https://drand.cloudflare.com".try_into().unwrap();
 
-// Get the latest beacon. By default, it verifies its signature against the chain info.
+// Get the latest beacon. By default, it verifies its signature against the chain info, and correlates the returned round number with the chain genesis time.
 let latest = client.latest()?;
 ```
 

--- a/drand_core/src/beacon.rs
+++ b/drand_core/src/beacon.rs
@@ -19,6 +19,8 @@ pub enum BeaconError {
     NotFound,
     #[error("parsing failed")]
     Parsing,
+    #[error("round mismatch")]
+    RoundMismatch,
     #[error("validation failed")]
     Validation,
 }


### PR DESCRIPTION
The beacon server might not returned the round the user asked for. If enabled, the verification should fail in this case. This commit also guards `HttpClient::latest` behinds the `time` feature. If `time` is not available, the method `HttpClient.get` has to be called instead.

The commit is co-authored, based on 8448548.

Closes #13 